### PR TITLE
Make code work even without shuriken-client

### DIFF
--- a/model/shurimock.py
+++ b/model/shurimock.py
@@ -1,0 +1,7 @@
+class ShurikenMonitor(object):
+    def send_info(self, epoch, logs=None):
+        pass
+
+
+def get_hparams():
+    pass

--- a/model/shurimock.py
+++ b/model/shurimock.py
@@ -4,4 +4,4 @@ class ShurikenMonitor(object):
 
 
 def get_hparams():
-    pass
+    return dict()

--- a/model/tadam.py
+++ b/model/tadam.py
@@ -37,9 +37,15 @@ import logging
 from common.util import summary_writer
 from common.gen_experiments import load_and_save_params
 import time
+import warnings
 # import Shuriken utilities
-from shuriken.callbacks import ShurikenMonitor
-from shuriken.utils import get_hparams
+try:
+    from shuriken.callbacks import ShurikenMonitor
+    from shuriken.utils import get_hparams
+except ImportError:
+    warnings.warn("Shuriken note available, mocking the utility functions")
+    from shurimock import ShurikenMonitor
+    from shurimock import get_hparams
 
 
 '''
@@ -1373,8 +1379,9 @@ def main(argv=None):
     # get the hyperparameters from the services
     # returns a dict of hyperparams
     hparams = get_hparams()
+    if 'n_iterations' in hparams:
+        hparams['number_of_steps'] = hparams['n_iterations'] * 100
     d_params.update(hparams)
-
 
     log_dir = get_logdir_name(flags=default_params)
 

--- a/model/tadam.py
+++ b/model/tadam.py
@@ -44,8 +44,8 @@ try:
     from shuriken.utils import get_hparams
 except ImportError:
     warnings.warn("Shuriken note available, mocking the utility functions")
-    from shurimock import ShurikenMonitor
-    from shurimock import get_hparams
+    from model.shurimock import ShurikenMonitor
+    from model.shurimock import get_hparams
 
 
 '''


### PR DESCRIPTION
Just in case this branch is used without having access to shuriken-client for the HP search, the code still executes.